### PR TITLE
Add /skill command for automated skill authoring

### DIFF
--- a/commands/skill.md
+++ b/commands/skill.md
@@ -1,9 +1,12 @@
-description = "Codify repeatable excellence from the current session into a 'great' and detailed new skill."
-prompt = """
+---
+description: Codify repeatable excellence from the current session into a 'great' and detailed new skill.
+---
+
 Activate the 'skill-author' skill.
+
 Objective: Identify a repeatable excellence or a specific high-quality workflow from this session that deserves to be a skill.
+
 1. Perform a deep, "great" analysis of the session's interactions, focusing on highly detailed moments of success.
 2. Use the 'skill-author' skill to design and create a new skill in the 'skills/' directory.
 3. The new skill must be extremely detailed, robust, and follow all 'skill-author' guidelines (SKILL.md, JSON by default, boundaries, etc.).
 4. Ensure the resulting skill captures the nuance and "greatness" of the session's best work.
-"""

--- a/commands/skill.toml
+++ b/commands/skill.toml
@@ -1,0 +1,9 @@
+description = "Codify repeatable excellence from the current session into a 'great' and detailed new skill."
+prompt = """
+Activate the 'skill-author' skill.
+Objective: Identify a repeatable excellence or a specific high-quality workflow from this session that deserves to be a skill.
+1. Perform a deep, "great" analysis of the session's interactions, focusing on highly detailed moments of success.
+2. Use the 'skill-author' skill to design and create a new skill in the 'skills/' directory.
+3. The new skill must be extremely detailed, robust, and follow all 'skill-author' guidelines (SKILL.md, JSON by default, boundaries, etc.).
+4. Ensure the resulting skill captures the nuance and "greatness" of the session's best work.
+"""

--- a/commands/skill.toml
+++ b/commands/skill.toml
@@ -1,12 +1,9 @@
----
-description: Codify repeatable excellence from the current session into a 'great' and detailed new skill.
----
-
+description = "Codify repeatable excellence from the current session into a 'great' and detailed new skill."
+prompt = """
 Activate the 'skill-author' skill.
-
 Objective: Identify a repeatable excellence or a specific high-quality workflow from this session that deserves to be a skill.
-
 1. Perform a deep, "great" analysis of the session's interactions, focusing on highly detailed moments of success.
 2. Use the 'skill-author' skill to design and create a new skill in the 'skills/' directory.
 3. The new skill must be extremely detailed, robust, and follow all 'skill-author' guidelines (SKILL.md, JSON by default, boundaries, etc.).
 4. Ensure the resulting skill captures the nuance and "greatness" of the session's best work.
+"""


### PR DESCRIPTION
Added a new command shortcut `/skill` in `commands/skill.toml`.
The command is designed to:
1. Activate the `skill-author` skill.
2. Analyze the current session for repeatable excellence.
3. Create a new, detailed, and high-quality skill in the `skills/` directory.
4. Follow the existing pattern of using `.toml` files for commands.

---
*PR created automatically by Jules for task [4674035480234568103](https://jules.google.com/task/4674035480234568103) started by @rmedranollamas*